### PR TITLE
Hide arrows and reduce pairs cell , these changes are only applied if screen size is 500px or less

### DIFF
--- a/src/archetypes/Pool/Row.js
+++ b/src/archetypes/Pool/Row.js
@@ -445,11 +445,19 @@ export default styled(({ address, className, yfl }) => {
     background: #445363;
   }
 
-  // Block has been added to handle pool name panel only if the browser size is 470px or less
-  @media (max-width: 470px) {
+  // Block has been added to handle pool panel only if the browser size is 500px or less
+  @media (max-width: 500px) {
     .pool-name
     {
       display:block!important;
+    }
+    .button-action // Hide arrows since the panel box is already clickable
+    {
+      display:none;
+    }
+    .suffix
+    {
+      display:flex;
     }
   }
 `;


### PR DESCRIPTION
Hide arrows and reduce pairs amount cell , and these changes are only applied if screen size is 500px or less

and regarding top menu I had difficulties fixing it since I'm not a react developer I'm just trying to help as much as I can, so it requires a huge change in code to make the top menu similar to LinkSwap or Gov Vault , which i prefer an expert react dev do it.

Old
Arrows:
![Old - 2](https://user-images.githubusercontent.com/32264894/102263387-4b06aa80-3f25-11eb-8a51-ffdff7c08eaf.PNG)
Pairs Amount:
![Old - 1](https://user-images.githubusercontent.com/32264894/102263390-4d690480-3f25-11eb-8ac8-99b04f26aa57.PNG)

Fixes
Arrows
![Fixed - 1](https://user-images.githubusercontent.com/32264894/102263416-53f77c00-3f25-11eb-9e90-c17bcb45e7c6.PNG)
Pairs amount:
![Fixed - 2](https://user-images.githubusercontent.com/32264894/102263419-5528a900-3f25-11eb-8314-f5ef2e713a93.PNG)


