### PR TITLE
Fix unclaimed CEL rewards display

### DIFF
--- a/src/archetypes/Pool/Row.js
+++ b/src/archetypes/Pool/Row.js
@@ -154,7 +154,12 @@ const HasPosition = styled(({ address, className }) => {
           >
             <LazyBoi
               value={position?.reward?.ert}
-              format={(val) => format.maxDB(units.fromWei(val), 5)}
+              format={(val) => {
+                if (position?.reward?.ert?.symbol === 'CEL') {
+                  return format.decimals(val * (10 ** 14), 5);
+                }
+                return format.maxDB(units.fromWei(val), 5);
+              }}
             />
           </Stat>
           <Button


### PR DESCRIPTION
This PR attempts to fix the display of CEL rewards due to it being a 4 decimal token.

**Note:**  I do not have a position and hence unclaimed rewards to test this change with, so it will need to be reviewed by someone who can perform this check.