### PR TITLE
Retry unclaimed CEL rewards display fix

### DIFF
--- a/src/archetypes/Pool/Row.js
+++ b/src/archetypes/Pool/Row.js
@@ -156,7 +156,7 @@ const HasPosition = styled(({ address, className }) => {
               value={position?.reward?.ert}
               format={(val) => {
                 if (position?.reward?.ert?.symbol === 'CEL') {
-                  return format.decimals(val * (10 ** 14), 5);
+                  return format.maxDB(val / 10000, 5);
                 }
                 return format.maxDB(units.fromWei(val), 5);
               }}


### PR DESCRIPTION
This is a second attempt at #8 fixing the unclaimed CEL rewards display.

**Please verify by testing through someone with an active LP rewards position in this pool.**