### PR TITLE
Change position to pool in CEL display fix

### DIFF
--- a/src/archetypes/Pool/Row.js
+++ b/src/archetypes/Pool/Row.js
@@ -155,7 +155,7 @@ const HasPosition = styled(({ address, className }) => {
             <LazyBoi
               value={position?.reward?.ert}
               format={(val) => {
-                if (position?.reward?.ert?.symbol === 'CEL') {
+                if (pool?.reward?.ert?.symbol === 'CEL') {
                   return format.maxDB(val / 10000, 5);
                 }
                 return format.maxDB(units.fromWei(val), 5);


### PR DESCRIPTION
This change *may* finally fix the display issue but I cannot test without an LP position (gas is too high for me to take the hit unfortunately).

**Please test with an actively staked LP position.**